### PR TITLE
use ApplyItem as the default action for FormattableString commands

### DIFF
--- a/src/Innovator.Client/Command.cs
+++ b/src/Innovator.Client/Command.cs
@@ -326,7 +326,7 @@ namespace Innovator.Client
     /// Create a command from an interpolated string
     /// </summary>
     /// <param name="formatted">Interpolated string to convert to a command</param>
-    public Command(FormattableString formatted)
+    public Command(FormattableString formatted) : this()
     {
       this.WithAml(formatted.Format, formatted.GetArguments());
       _sub.Style = ParameterStyle.CSharp;


### PR DESCRIPTION
The implicit conversion from `FormattableString` to `Command` was creating commands with an `Action` of `CommandAction.ActivateActivity` instead of `CommandAction.ApplyItem`.

This looks like it was just a simple mistake where you forgot to delegate to the parameterless constructor.  