### PR TITLE
Updating AsString to never return a null

### DIFF
--- a/src/Innovator.Client/Aml/Simple/Attribute.cs
+++ b/src/Innovator.Client/Aml/Simple/Attribute.cs
@@ -129,7 +129,7 @@ namespace Innovator.Client
     {
       if (!this.Exists)
         return defaultValue;
-      return this.Value;
+      return this.Value ?? defaultValue;
     }
 
     public static Attribute TryGet(object value, Element newParent)

--- a/src/Innovator.Client/Aml/Simple/IdAnnotation.cs
+++ b/src/Innovator.Client/Aml/Simple/IdAnnotation.cs
@@ -37,9 +37,10 @@ namespace Innovator.Client
     {
       return _value;
     }
+
     public string AsString(string defaultValue)
     {
-      return this.Value;
+      return this.Value ?? defaultValue;
     }
 
     #region IReadOnlyProperty

--- a/src/Innovator.Client/Aml/Simple/Property.cs
+++ b/src/Innovator.Client/Aml/Simple/Property.cs
@@ -183,7 +183,7 @@ namespace Innovator.Client
     {
       if (!this.Exists || Attribute("is_null").AsBoolean(false))
         return defaultValue;
-      return this.Value;
+      return this.Value ?? defaultValue;
     }
 
     public override IElement Add(object content)

--- a/src/Innovator.Client/IOM/Attribute.cs
+++ b/src/Innovator.Client/IOM/Attribute.cs
@@ -93,7 +93,7 @@ namespace Innovator.Client.IOM
     public string AsString(string defaultValue)
     {
       if (_node == null) return defaultValue;
-      return this.Value;
+      return this.Value ?? defaultValue;
     }
 
     public void Remove()

--- a/src/Innovator.Client/IOM/Property.cs
+++ b/src/Innovator.Client/IOM/Property.cs
@@ -162,7 +162,7 @@ namespace Innovator.Client.IOM
     {
       if (!this.Exists || Attribute("is_null").AsBoolean(false))
         return defaultValue;
-      return this.Value;
+      return this.Value ?? defaultValue;
     }
 
     public override IElement Add(object content)


### PR DESCRIPTION
The expectation of AsString is to replace all nulls with the default value. There is a case where an empty element can exist without an is_null, but the underlying value is still null. We should return the default value in this case as well.