### PR TITLE
Add AssertNoError overload for ignoring NoItemsFound

### DIFF
--- a/src/Innovator.Client/Aml/IResult.cs
+++ b/src/Innovator.Client/Aml/IResult.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Innovator.Client
 {
@@ -76,11 +76,16 @@ namespace Innovator.Client
     /// <exception cref="ServerException">If the result does not have at least one item, either the exception returned from 
     /// the server or a new exception will be thrown</exception>
     IEnumerable<IReadOnlyItem> AssertItems();
-    /// <summary>Do nothing other than throw an exception if there is an error other than 'No Items Found'</summary>
+    /// <summary>Do nothing other than throw an exception if present</summary>
     /// <exception cref="ServerException">If an exception was returned from the server (including 
     /// <see cref="NoItemsFoundException"/>), the exception will be thrown</exception>
     /// <returns>The current <see cref="IReadOnlyResult"/> for chaining additional methods</returns>
     IReadOnlyResult AssertNoError();
+    /// <summary>Do nothing other than throw an exception if present, optionally ignoring <see cref="NoItemsFoundException"/></summary>
+    /// <exception cref="ServerException">If an exception was returned from the server (optionally including 
+    /// <see cref="NoItemsFoundException"/>), the exception will be thrown</exception>
+    /// <returns>The current <see cref="IReadOnlyResult"/> for chaining additional methods</returns>
+    IReadOnlyResult AssertNoError(bool ignoreNoItemsFound);
     /// <summary>Return an exception (if there is one), otherwise, return <c>null</c></summary>
     ServerException Exception { get; }
     /// <summary>Return an enumerable of items.  Throw an exception if there is an error other than 'No Items Found'</summary>

--- a/src/Innovator.Client/Aml/Simple/Result.cs
+++ b/src/Innovator.Client/Aml/Simple/Result.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
@@ -115,9 +115,22 @@ namespace Innovator.Client
       return items;
     }
 
+    /// <summary>
+    /// Do nothing other than throw an exception if present
+    /// </summary>
     public IReadOnlyResult AssertNoError()
     {
+      this.AssertNoError(false);
+      return this;
+    }
+
+    /// <summary>
+    /// Do nothing other than throw an exception if present, optionally ignoring <see cref="NoItemsFoundException"/>
+    /// </summary>
+    public IReadOnlyResult AssertNoError(bool ignoreNoItemsFound)
+    {
       var exception = this.Exception;
+      if (exception is NoItemsFoundException && ignoreNoItemsFound) return this;
       if (exception != null) throw exception;
       return this;
     }

--- a/src/Innovator.Client/IOM/Item.cs
+++ b/src/Innovator.Client/IOM/Item.cs
@@ -64,7 +64,7 @@ namespace Innovator.Client.IOM
       loadAML(result);
     }
 
-#region IReadOnlyResult    
+    #region IReadOnlyResult    
     /// <summary>
     /// Return an exception (if there is one), otherwise, return <c>null</c>
     /// </summary>
@@ -119,12 +119,21 @@ namespace Innovator.Client.IOM
     }
 
     /// <summary>
-    /// Do nothing other than throw an exception if there is an error other than 'No Items Found'
+    /// Do nothing other than throw an exception if present
     /// </summary>
-    /// <returns></returns>
     public IReadOnlyResult AssertNoError()
     {
+      this.AssertNoError(false);
+      return this;
+    }
+
+    /// <summary>
+    /// Do nothing other than throw an exception if present, optionally ignoring <see cref="NoItemsFoundException"/>
+    /// </summary>
+    public IReadOnlyResult AssertNoError(bool ignoreNoItemsFound)
+    {
       var exception = this.Exception;
+      if (exception is NoItemsFoundException && ignoreNoItemsFound) return this;
       if (exception != null) throw exception;
       return this;
     }
@@ -206,9 +215,9 @@ namespace Innovator.Client.IOM
         ? (Exception)NewNoItemsException()
         : new InvalidOperationException("Multiple items were found when only one was expected."));
     }
-#endregion
+    #endregion
 
-#region IItem
+    #region IItem
 
     /// <summary>
     /// Retrieve the parent element
@@ -479,12 +488,12 @@ namespace Innovator.Client.IOM
     {
       return AssertItem().TypeName();
     }
-#endregion
+    #endregion
 
-#region ISingleItemContext
+    #region ISingleItemContext
     IReadOnlyItem ISingleItemContext.Item { get { return AssertItem(); } }
     IServerConnection IContext.Conn { get { return (IServerConnection)_conn; } }
-#endregion
+    #endregion
 
     /// <summary>
     /// Returns a <see cref="System.String" /> that represents this instance.

--- a/src/Innovator.ClientTests/Aml/ServerExceptionTests.cs
+++ b/src/Innovator.ClientTests/Aml/ServerExceptionTests.cs
@@ -107,6 +107,31 @@ namespace Innovator.Client.Tests
     }
 
     [TestMethod()]
+    public void AssertNoErrorNoItemsFound()
+    {
+      var aml = @"<SOAP-ENV:Envelope xmlns:SOAP-ENV=""http://schemas.xmlsoap.org/soap/envelope/"">
+  <SOAP-ENV:Body>
+    <SOAP-ENV:Fault xmlns:af=""http://www.aras.com/InnovatorFault"">
+      <faultcode>0</faultcode>
+      <faultstring>No items of type SavedSearch found.</faultstring>
+    </SOAP-ENV:Fault>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>";
+
+      var result = ElementFactory.Local.FromXml(aml);
+      try
+      {
+        result.AssertNoError(true);
+      }
+      catch (NoItemsFoundException)
+      {
+        Assert.Fail("AssertNoError(true) should not throw NoItemsFoundExceptions");
+      }
+      Assert.ThrowsException<NoItemsFoundException>(() => result.AssertNoError());
+      Assert.ThrowsException<NoItemsFoundException>(() => result.AssertNoError(false));
+    }
+
+    [TestMethod()]
     public void ValidationReportException()
     {
       var aml = ElementFactory.Local;


### PR DESCRIPTION
Creating the ability to just use AssertNoError when you are okay with not finding any items and don't want to access it with .Items()