### PR TITLE
Allow both IReadOnlyItems and IItems to be added to a Result

### DIFF
--- a/src/Innovator.Client/Aml/IItem.cs
+++ b/src/Innovator.Client/Aml/IItem.cs
@@ -1,9 +1,9 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Innovator.Client
 {
   /// <summary>
-  /// Represents an Aras Item that is read only.  By default, the connection object returns IReadOnlyItems to encouarge
+  /// Represents an Aras Item that is read only.  By default, the connection object returns IReadOnlyItems to encourage
   /// treating the results as immutable
   /// </summary>
   /// <remarks>

--- a/src/Innovator.Client/Aml/IResult.cs
+++ b/src/Innovator.Client/Aml/IResult.cs
@@ -34,7 +34,7 @@ namespace Innovator.Client
     /// <summary>Add the specified item to the result</summary>
     /// <param name="item">Item to add</param>
     /// <returns>The current <see cref="IResult"/> object for chaining additional commands</returns>
-    IResult Add(IItem item);
+    IResult Add(IReadOnlyItem item);
     /// <summary>Adds content to the <c>Message</c> element of the result tag</summary>
     /// <param name="content">Content to add to the <c>Message</c> element</param>
     void AddMessage(params object[] content);

--- a/src/Innovator.Client/Aml/Simple/Result.cs
+++ b/src/Innovator.Client/Aml/Simple/Result.cs
@@ -62,7 +62,7 @@ namespace Innovator.Client
       _query = query;
     }
 
-    public IResult Add(IItem content)
+    public IResult Add(IReadOnlyItem content)
     {
       AddReadOnly(content);
       return this;

--- a/src/Innovator.ClientTests/Aml/ItemTests.cs
+++ b/src/Innovator.ClientTests/Aml/ItemTests.cs
@@ -818,5 +818,18 @@ namespace Innovator.Client.Tests
 
       Assert.AreEqual("id,state,keyed_name", item.Select().Value);
     }
+
+    [TestMethod]
+    public void AddReadOnlyItemsToResult()
+    {
+      var result = ElementFactory.Local.Result();
+      var resultItem = ElementFactory.Local.Item();
+      result.Add(resultItem);
+
+      var readonlyResultItem = resultItem.AsResult().AssertItem();
+      result.Add(readonlyResultItem);
+
+      Assert.AreEqual(2, result.Items().Count());
+    }
   }
 }


### PR DESCRIPTION
Currently you have to clone a IReadOnlyItem in order to add it to a Result. This seems like an unnecessary step when we could just add both as a IReadOnlyItem.