### PR TITLE
Always dispose the HttpRequest for vault uploads in order to release the OS file handle

### DIFF
--- a/src/Innovator.Client/Connection/TransactionalUploadCommand.cs
+++ b/src/Innovator.Client/Connection/TransactionalUploadCommand.cs
@@ -152,7 +152,10 @@ namespace Innovator.Client
             { "version", _conn.Version }
           };
           var uri = new Uri(Vault.Url + "?fileId=" + file.Id);
-          return Vault.HttpClient.PostPromise(uri, async, req, trace).Always(trace.Dispose);
+          return Vault.HttpClient
+          .PostPromise(uri, async, req, trace)
+          .Always(trace.Dispose)
+          .Always(req.Dispose);
         })
         .Convert(r => r.AsStream);
     }

--- a/src/Innovator.Client/UploadCommand.cs
+++ b/src/Innovator.Client/UploadCommand.cs
@@ -347,7 +347,10 @@ namespace Innovator.Client
             || string.Equals(name, "TIMEZONE_NAME", StringComparison.OrdinalIgnoreCase))
             trace.Add(name.ToLowerInvariant(), value);
         });
-        return Vault.HttpClient.PostPromise(new Uri(Vault.Url), async, req, trace).Always(trace.Dispose);
+        return Vault.HttpClient
+        .PostPromise(new Uri(Vault.Url), async, req, trace)
+        .Always(trace.Dispose)
+        .Always(req.Dispose);
       }).Convert(r => r.AsStream);
     }
 

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.27.1" />
+    <package id="Cake" version="0.35.0" />
 </packages>


### PR DESCRIPTION
We ran into an issue where we couldn't delete a file we had just created and uploaded to Aras because there was still a file system handle open. Disposing the HttpRequest removed the handle.