### PR TITLE
Fix casing on Aras PLM escalation

### DIFF
--- a/src/Innovator.Client/Server/Extensions.cs
+++ b/src/Innovator.Client/Server/Extensions.cs
@@ -19,14 +19,14 @@ namespace Innovator.Server
     }
 
     /// <summary>
-    /// Adds "Aras Plm" to the identity list of the current connection
+    /// Adds "Aras PLM" to the identity list of the current connection
     /// </summary>
     /// <param name="conn">The connection to escalate.</param>
     /// <returns>A <see cref="IDisposable"/> object.  Calling <see cref="IDisposable.Dispose"/> will 
     /// return the identity list to its original state</returns>
     public static IDisposable AsArasPlm(this IServerConnection conn)
     {
-      return conn.Permissions.Escalate("Aras Plm");
+      return conn.Permissions.Escalate("Aras PLM");
     }
   }
 }

--- a/src/Innovator.Client/Server/IServerPermissions.cs
+++ b/src/Innovator.Client/Server/IServerPermissions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace Innovator.Server
@@ -27,11 +27,11 @@ namespace Innovator.Server
     /// <returns>A list of identities that the user <paramref name="userId"/> is in.</returns>
     IEnumerable<string> Identities(string userId);
     /// <summary>
-    /// Adds the <paramref name="identNames"/> identity to the identity list of the current connection
+    /// Adds the case-sensitive <paramref name="identityNames"/> to the identity list of the current connection.
     /// </summary>
-    /// <param name="identNames">Names of the identities to add</param>
+    /// <param name="identityNames">Case-sensitive names of the identities to add</param>
     /// <returns>A <see cref="IDisposable"/> object.  Calling <see cref="IDisposable.Dispose"/> will 
     /// return the identity list to its original state</returns>
-    IDisposable Escalate(params string[] identNames);
+    IDisposable Escalate(params string[] identityNames);
   }
 }


### PR DESCRIPTION
My previous fix did not actually work as Aras.Server.Security.Identity.GetByName in IomConnection.cs is case-sensitive.