### PR TITLE
Support setting CDATA values with Property().Set()

### DIFF
--- a/src/Innovator.Client/Aml/Simple/Element.cs
+++ b/src/Innovator.Client/Aml/Simple/Element.cs
@@ -376,15 +376,23 @@ namespace Innovator.Client
         {
           writer.WriteAttributeString(attr.Name, attr.Value);
         }
-
       }
-      var elem = _content as ILinkedElement;
-      if (elem == null)
+      if (!(_content is ILinkedElement))
       {
-        if (PreferCData && this.Value?.IndexOf("<![CDATA[") < 0)
+        var startsWithCData = this.Value?.StartsWith("<![CDATA[");
+        if (PreferCData && startsWithCData != true)
+        {
+          // Write a CData tag even when this.Value is null
           writer.WriteCData(this.Value);
+        }
+        else if (startsWithCData == true)
+        {
+          writer.WriteRaw(this.Value);
+        }
         else
+        {
           writer.WriteString(this.Value);
+        }
       }
       else
       {

--- a/src/Innovator.ClientTests/Aml/PropertyTests.cs
+++ b/src/Innovator.ClientTests/Aml/PropertyTests.cs
@@ -1,7 +1,7 @@
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Innovator.Client.Tests
 {
@@ -116,6 +116,15 @@ namespace Innovator.Client.Tests
       var item = aml.Item(aml.Property("prop1", aml.Attribute("keyed_name", "some name"), "value1"), aml.Property("prop2", aml.Attribute("keyed_name", "another name"), "value2"));
       var item2 = aml.Item(item.Property("prop1"));
       Assert.AreEqual("some name", item2.Property("prop1").KeyedName().Value);
+    }
+
+    [TestMethod()]
+    public void PropertySetCdata()
+    {
+      const string str = "<Item><name><![CDATA[first & second > third]]></name></Item>";
+      var item = ElementFactory.Local.Item();
+      item.Property("name").Set("<![CDATA[first & second > third]]>");
+      Assert.AreEqual(str, item.ToAml());
     }
   }
 }


### PR DESCRIPTION
Without this fix Property().Set() will encode the entire value, including the CDATA tag characters