### PR TITLE
Vault Connection Partial Content Responses

### DIFF
--- a/src/Innovator.Client/AssemblyInfo.Version.cs
+++ b/src/Innovator.Client/AssemblyInfo.Version.cs
@@ -5,6 +5,6 @@
 //------------------------------------------------------------------------------
 using System.Reflection;
 
-[assembly: AssemblyVersion("2019.08.04.1157")]
-[assembly: AssemblyFileVersion("2019.08.04.1157")]
+[assembly: AssemblyVersion("2020.07.09.1551")]
+[assembly: AssemblyFileVersion("2020.07.09.1551")]
 

--- a/src/Innovator.Client/Connection/ArasHttpConnection.cs
+++ b/src/Innovator.Client/Connection/ArasHttpConnection.cs
@@ -21,7 +21,6 @@ namespace Innovator.Client.Connection
     private readonly Uri _innovatorServerUrl;
     private readonly Uri _innovatorClientBin;
     private List<Action<IHttpRequest>> _defaults = new List<Action<IHttpRequest>>();
-    private readonly ArasVaultConnection _vaultConn;
     private readonly List<KeyValuePair<string, string>> _serverInfo = new List<KeyValuePair<string, string>>();
 
 
@@ -83,6 +82,11 @@ namespace Innovator.Client.Connection
     public Version Version { get; private set; }
 
     /// <summary>
+    /// Connection to Aras Vault
+    /// </summary>
+    public ArasVaultConnection VaultConn { get; set; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="ArasHttpConnection"/> class.
     /// </summary>
     /// <param name="service">The service.</param>
@@ -112,7 +116,7 @@ namespace Innovator.Client.Connection
       this._innovatorServerUrl = new Uri(this.Url, "InnovatorServer.aspx");
       this._innovatorClientBin = new Uri(this.Url, "../Client/cbin/");
 
-      _vaultConn = new ArasVaultConnection(this, Service);
+      VaultConn = new ArasVaultConnection(this, Service);
     }
 
     /// <summary>
@@ -127,7 +131,7 @@ namespace Innovator.Client.Connection
       if (upload == null)
       {
         if (request.Action == CommandAction.DownloadFile)
-          return _vaultConn.Download(request, false).Value;
+          return VaultConn.Download(request, false).Value;
 
         return UploadAml(_innovatorServerUrl, request.Action.ToString(), request, false).Value.AsStream;
       }
@@ -145,7 +149,7 @@ namespace Innovator.Client.Connection
       if (upload == null)
       {
         if (request.Action == CommandAction.DownloadFile)
-          return _vaultConn.Download(request, async);
+          return VaultConn.Download(request, async);
 
         return UploadAml(_innovatorServerUrl, request.Action.ToString(), request, async)
           .Convert(r => r.AsStream);
@@ -156,7 +160,7 @@ namespace Innovator.Client.Connection
       }
 
       // Files need to be uploaded, so build the vault request
-      return _vaultConn.Upload(upload, async);
+      return VaultConn.Upload(upload, async);
     }
 
     /// <summary>
@@ -167,7 +171,7 @@ namespace Innovator.Client.Connection
     /// </returns>
     public UploadCommand CreateUploadCommand()
     {
-      return _vaultConn.CreateUploadCommand();
+      return VaultConn.CreateUploadCommand();
     }
 
     /// <summary>
@@ -322,7 +326,7 @@ namespace Innovator.Client.Connection
                 }
               }
 
-              _vaultConn.InitializeStrategy();
+              VaultConn.InitializeStrategy();
               result.Resolve(UserId);
             }
           }).Fail(ex =>
@@ -379,8 +383,8 @@ namespace Innovator.Client.Connection
     /// <param name="strategy">The strategy.</param>
     public void SetVaultStrategy(IVaultStrategy strategy)
     {
-      _vaultConn.VaultStrategy = strategy;
-      if (!string.IsNullOrEmpty(UserId)) _vaultConn.InitializeStrategy();
+      VaultConn.VaultStrategy = strategy;
+      if (!string.IsNullOrEmpty(UserId)) VaultConn.InitializeStrategy();
     }
 
     private IPromise<IHttpResponse> UploadAml(Uri uri, string action, Command request, bool async, HttpClient service = null)

--- a/src/Innovator.Client/Connection/ArasVaultConnection.cs
+++ b/src/Innovator.Client/Connection/ArasVaultConnection.cs
@@ -90,6 +90,18 @@ namespace Innovator.Client.Connection
     /// <returns>A promise to return a stream of the file's bytes</returns>
     public IPromise<Stream> Download(Command request, bool async)
     {
+      return DownloadRaw(request, async).Convert(r => r.AsStream);
+    }
+
+    /// <summary>
+    /// Downloads the specified file.
+    /// </summary>
+    /// <param name="request">The file to download.</param>
+    /// <param name="async">if set to <c>true</c>, download asynchronously.  Otherwise, 
+    /// a resolved promise will be returned</param>
+    /// <returns>A promise to return a IHttpResponse of the file</returns>
+    public IPromise<IHttpResponse> DownloadRaw(Command request, bool async)
+    {
       var parsedAml = _conn.AmlContext.FromXml(request);
       var file = (IReadOnlyItem)parsedAml.AssertItem("File");
       var hasVaults = file.Relationships("Located")
@@ -110,8 +122,7 @@ namespace Innovator.Client.Connection
 
           // Download the file
           return DownloadFileFromVault(o.Result1, vault, async, request);
-        })
-        .Convert(r => r.AsStream);
+        });
     }
 
     private Vault GetReadVaultForFile(IReadOnlyItem file, IEnumerable<Vault> readPriority)

--- a/src/Innovator.Client/Connection/ConnectionPool.cs
+++ b/src/Innovator.Client/Connection/ConnectionPool.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using Innovator.Client.Connection;
+using System;
 using System.IO;
 using System.Threading;
 
@@ -63,6 +64,11 @@ namespace Innovator.Client
     /// ID of the authenticated user
     /// </summary>
     public string UserId { get { return _ref.UserId; } }
+
+    /// <summary>
+    /// Connection to Aras Vault
+    /// </summary>
+    public ArasVaultConnection VaultConn { get { return _ref.VaultConn; } }
 
     /// <summary>
     /// Creates an upload request used for uploading files to the server

--- a/src/Innovator.Client/Connection/MappedConnection.cs
+++ b/src/Innovator.Client/Connection/MappedConnection.cs
@@ -58,6 +58,8 @@ namespace Innovator.Client.Connection
       }
     }
 
+    public ArasVaultConnection VaultConn { get => _current.VaultConn; }
+
     public MappedConnection(IEnumerable<ServerMapping> mappings
       , Func<INetCredentials, string, bool, IPromise<ICredentials>> authCallback)
     {

--- a/src/Innovator.Client/IConnection.cs
+++ b/src/Innovator.Client/IConnection.cs
@@ -1,4 +1,6 @@
-﻿namespace Innovator.Client
+using Innovator.Client.Connection;
+
+namespace Innovator.Client
 {
   /// <summary>
   /// Interface for a connection to an Aras Innovator instance
@@ -19,6 +21,11 @@
     /// ID of the authenticated user
     /// </summary>
     string UserId { get; }
+
+    /// <summary>
+    /// Connection to Aras Vault
+    /// </summary>
+    ArasVaultConnection VaultConn { get; }
 
     /// <summary>
     /// Calls a SOAP action asynchronously

--- a/src/Innovator.Client/IO/HttpResponse.cs
+++ b/src/Innovator.Client/IO/HttpResponse.cs
@@ -37,7 +37,7 @@ namespace Innovator.Client
         var result = new HttpResponse
         {
           _statusCode = task.Result.StatusCode,
-          _headers = task.Result.Headers.ToDictionary(k => k.Key, k => k.Value.First())
+          _headers = task.Result.Headers.Concat(task.Result.Content.Headers).ToDictionary(k => k.Key, k => k.Value.First())
         };
         task.Result.Content.ReadAsStreamAsync().ContinueWith(t =>
         {

--- a/src/Innovator.Client/IOM/IomConnection.cs
+++ b/src/Innovator.Client/IOM/IomConnection.cs
@@ -24,7 +24,6 @@ namespace Innovator.Client.IOM
     protected string _httpDatabase;
     protected string _httpPassword;
     protected string _httpUsername;
-    private readonly ArasVaultConnection _vaultConn;
     protected Uri _innovatorClientBin;
     protected Uri _requestUrl;
     protected object _iomConnection;
@@ -101,7 +100,7 @@ namespace Innovator.Client.IOM
       }
 
       AmlContext = new ElementFactory(context, itemFactory);
-      _vaultConn = new ArasVaultConnection(this);
+      VaultConn = new ArasVaultConnection(this);
     }
 
     /// <summary>
@@ -153,8 +152,8 @@ namespace Innovator.Client.IOM
     {
       var version = Version ?? new Version(255, 0);
       if (version.Major > 9)
-        return new TransactionalUploadCommand(this, _vaultConn.VaultStrategy.WritePriority(false).Value.First());
-      return new NontransactionalUploadCommand(this, _vaultConn.VaultStrategy.WritePriority(false).Value.First());
+        return new TransactionalUploadCommand(this, VaultConn.VaultStrategy.WritePriority(false).Value.First());
+      return new NontransactionalUploadCommand(this, VaultConn.VaultStrategy.WritePriority(false).Value.First());
     }
 
     /// <summary>
@@ -196,7 +195,7 @@ namespace Innovator.Client.IOM
       if (upload == null)
       {
         if (request.Action == CommandAction.DownloadFile)
-          return _vaultConn.Download(request, async);
+          return VaultConn.Download(request, async);
 
         var input = new XmlDocument();
         input.LoadXml(request.ToNormalizedAml(AmlContext.LocalizationContext));
@@ -223,7 +222,7 @@ namespace Innovator.Client.IOM
       }
 
       // Files need to be uploaded, so build the vault request
-      return _vaultConn.Upload(upload, async);
+      return VaultConn.Upload(upload, async);
     }
 
     /// <summary>
@@ -270,7 +269,7 @@ namespace Innovator.Client.IOM
       return Promises.Resolved(this.Version);
     }
 
-#region "Server Connection"    
+    #region "Server Connection"    
     /// <summary>
     /// Gets the in-memory application-wide cache.
     /// </summary>
@@ -411,6 +410,8 @@ namespace Innovator.Client.IOM
       }
     }
 
+    public ArasVaultConnection VaultConn { get; }
+
     /// <summary>
     /// Gets the HTTP header by name.
     /// </summary>
@@ -520,7 +521,7 @@ namespace Innovator.Client.IOM
       }
     }
 
-#endregion
+    #endregion
 
     protected virtual void LazyLoadCreds()
     {

--- a/src/Innovator.Client/Innovator.Client.Net35.csproj
+++ b/src/Innovator.Client/Innovator.Client.Net35.csproj
@@ -53,6 +53,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Aml\AmlSqlPermissionOption.cs" />
+    <Compile Include="Aml\CDataValue.cs" />
     <Compile Include="Aml\DateTimeZone.cs" />
     <Compile Include="Aml\ICoercible.cs" />
     <Compile Include="Aml\SqlRenderOption.cs" />

--- a/src/Innovator.Client/Innovator.Client.Net45.csproj
+++ b/src/Innovator.Client/Innovator.Client.Net45.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>

--- a/src/Innovator.ClientTests/TestConnection.cs
+++ b/src/Innovator.ClientTests/TestConnection.cs
@@ -40,6 +40,8 @@ namespace Innovator.Client.Tests
   </SOAP-ENV:Body>
 </SOAP-ENV:Envelope>";
 
+    public ArasVaultConnection VaultConn { get { return _vaultConn; } }
+
     public TestConnection()
     {
       _vaultConn = new ArasVaultConnection(this);

--- a/src/Innovator.ClientTests/UploadCommandTests.cs
+++ b/src/Innovator.ClientTests/UploadCommandTests.cs
@@ -1,3 +1,4 @@
+using Innovator.Client.Connection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
@@ -8,6 +9,28 @@ namespace Innovator.Client.Tests
   [TestClass()]
   public class UploadCommandTests
   {
+    [TestMethod()]
+    public async System.Threading.Tasks.Task DownloadFile()
+    {
+      var prefs = new ConnectionPreferences()
+      {
+        Url = "http://ct.gentex.com/gentexinnovator/",
+        Credentials = new ExplicitCredentials("PROD", "username", "password")
+      };
+      var conn = Factory.GetConnection(prefs);
+      conn.Login(prefs.Credentials);
+
+      var download = new Command("<Item action='get' type='File' id='3C43F9CB05F54DCC96F91DB108F1D207'></Item>")
+        .WithAction(CommandAction.DownloadFile);
+
+      download.Settings = x => x.SetHeader("Range", "bytes=0-100");
+
+      var downloadResponse = await conn.VaultConn.DownloadRaw(download, true);
+
+
+      Assert.IsTrue(true);
+    }
+
     //[TestMethod()]
     //public void UploadFile11_VerifyHttp()
     //{

--- a/src/Innovator.ClientTests/UploadCommandTests.cs
+++ b/src/Innovator.ClientTests/UploadCommandTests.cs
@@ -1,35 +1,33 @@
-using Innovator.Client.Connection;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
 using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Innovator.Client.Tests
 {
   [TestClass()]
   public class UploadCommandTests
   {
-    [TestMethod()]
-    public async System.Threading.Tasks.Task DownloadFile()
-    {
-      var prefs = new ConnectionPreferences()
-      {
-        Url = "http://ct.gentex.com/gentexinnovator/",
-        Credentials = new ExplicitCredentials("PROD", "username", "password")
-      };
-      var conn = Factory.GetConnection(prefs);
-      conn.Login(prefs.Credentials);
+    //[TestMethod()]
+    //public async System.Threading.Tasks.Task DownloadRaw_VerifyRangeAndContentLengthHeaders()
+    //{
+    //  var prefs = new ConnectionPreferences()
+    //  {
+    //    Url = "http://ct.gentex.com/gentexinnovator/",
+    //    Credentials = new ExplicitCredentials("PROD", "username", "password")
+    //  };
+    //  var conn = Factory.GetConnection(prefs);
+    //  conn.Login(prefs.Credentials);
 
-      var download = new Command("<Item action='get' type='File' id='3C43F9CB05F54DCC96F91DB108F1D207'></Item>")
-        .WithAction(CommandAction.DownloadFile);
+    //  var download = new Command("<Item action='get' type='File' id='3C43F9CB05F54DCC96F91DB108F1D207'></Item>")
+    //    .WithAction(CommandAction.DownloadFile);
 
-      download.Settings = x => x.SetHeader("Range", "bytes=0-100");
+    //  download.Settings = x => x.SetHeader("Range", "bytes=0-99");
 
-      var downloadResponse = await conn.VaultConn.DownloadRaw(download, true);
+    //  var downloadResponse = await conn.VaultConn.DownloadRaw(download, true);
 
-
-      Assert.IsTrue(true);
-    }
+    //  Assert.AreEqual("100", downloadResponse.Headers["Content-Length"]);
+    //}
 
     //[TestMethod()]
     //public void UploadFile11_VerifyHttp()


### PR DESCRIPTION
This PR allows for the ability to receive partial file responses using the ArasVaultConnection from a IConnection.
The changes:
1. A DownloadRaw function that returns the HttpResponse instead of just a stream
2. Returning the Content Headers in the HttpResponse
3. Making the internal ArasVaultConnection accessible publicly
We thought about making a ProcessRaw and UploadRaw in order to match the DownloadRaw but the scope of changes quickly grew.