### PR TITLE
Fix LazyMap so that the database get does not completely overwrite the incoming item

### DIFF
--- a/src/Innovator.Client/Aml/ItemExtensions.cs
+++ b/src/Innovator.Client/Aml/ItemExtensions.cs
@@ -1120,11 +1120,16 @@ namespace Innovator.Client
             foreach (var databaseElement in databaseItem.Elements())
             {
               var incomingProp = incomingItem.Property(databaseElement.Name);
-              if (!incomingProp.Exists)
+              // We want to take the database property if:
+              // The property does not exist on the incoming item
+              // Or the database value is the same as the incoming
+              //  - In this case we may be getting additional props from the database that we don't already have
+              if (!incomingProp.Exists || incomingProp.Value == databaseElement.Value)
               {
                 incomingProp.Remove();
                 incomingItem.Add(databaseElement);
               }
+              // TODO: Retrieve the data for the new value
             }
             results[tuple.Key] = mapper.Invoke(incomingItem);
           }

--- a/src/Innovator.Client/Aml/Simple/Element.cs
+++ b/src/Innovator.Client/Aml/Simple/Element.cs
@@ -145,9 +145,11 @@ namespace Innovator.Client
     protected void CopyData(IReadOnlyElement elem)
     {
       Add(elem.Attributes());
-      Add(elem.Elements());
-      if (elem.Value != null)
-        Add(elem.Value);
+      var elements = elem.Elements();
+      if (elements.Any())
+        Add(elements);
+      else if (elem.Value != null)
+        Add(elem.Value); // Only set the value if there are no elements as it will overwrite the elements
     }
 
     /// <summary>Add new content to the element</summary>

--- a/src/Innovator.ClientTests/Aml/ItemExtensionsTests.cs
+++ b/src/Innovator.ClientTests/Aml/ItemExtensionsTests.cs
@@ -142,6 +142,28 @@ namespace Innovator.Client.Tests
     }
 
     [TestMethod()]
+    public void LazyMap_NestedItem_RetrieveExtraData()
+    {
+      var conn = new TestConnection();
+      var aml = ElementFactory.Local;
+      var item = aml.FromXml(@"<Result><Item type='Company' typeId='3E71E373FC2940B288760C915120AABE' id='0E086FFA6C4646F6939B74C43D094182'>
+  <id keyed_name='Another Company' type='Company'>0E086FFA6C4646F6939B74C43D094182</id>
+  <permission_id keyed_name='Company' type='Permission'>A8FC3EC44ED0462B9A32D4564FAC0AD8</permission_id>
+  <itemtype>3E71E373FC2940B288760C915120AABE</itemtype>
+</Item></Result>").AssertItem();
+      var result = item.LazyMap(conn, i => new
+      {
+        ItemType = i.Property("itemtype").Value,
+        PermissionItem = i.Property("permission_id").AsItem(),
+        PermissionItemId = i.Property("permission_id").AsItem().Id(),
+        PermissionName = i.Property("permission_id").AsItem().Property("name").Value
+      });
+      Assert.AreEqual("3E71E373FC2940B288760C915120AABE", result.ItemType);
+      Assert.AreEqual("A8FC3EC44ED0462B9A32D4564FAC0AD8", result.PermissionItemId);
+      Assert.AreEqual("Company", result.PermissionName);
+    }
+
+    [TestMethod()]
     public void RenderingComposedItemsTest()
     {
       var conn = new TestConnection();

--- a/src/Innovator.ClientTests/Aml/ItemExtensionsTests.cs
+++ b/src/Innovator.ClientTests/Aml/ItemExtensionsTests.cs
@@ -1,7 +1,7 @@
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
 using System.Xml.Linq;
 using System.Xml.XPath;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Innovator.Client.Tests
 {
@@ -82,6 +82,63 @@ namespace Innovator.Client.Tests
       Assert.AreEqual(null, result.PermName);
       Assert.AreEqual("Some Company", result.KeyedName);
       Assert.AreEqual(null, result.Empty);
+    }
+
+    [TestMethod()]
+    public void LazyMap_PropertyDoesNotExistInDatabase()
+    {
+      var conn = new TestConnection();
+      var aml = ElementFactory.Local;
+      var item = aml.FromXml(@"<Result><Item type='Company' typeId='3E71E373FC2940B288760C915120AABE' id='0E086FFA6C4646F6939B74C43D094182' fake_attr='This is a fake attribute for passing data'>
+  <created_by_id keyed_name='First Last' type='User'>
+    <Item type='User' typeId='45E899CD2859442982EB22BB2DF683E5' id='8227040ABF0A46A8AF06C18ABD3967B3'>
+      <id keyed_name='First Last' type='User'>8227040ABF0A46A8AF06C18ABD3967B3</id>
+      <first_name>First</first_name>
+      <itemtype>45E899CD2859442982EB22BB2DF683E5</itemtype>
+    </Item>
+  </created_by_id>
+  <id keyed_name='Another Company' type='Company'>0E086FFA6C4646F6939B74C43D094182</id>
+  <permission_id keyed_name='Company' type='Permission'>
+    <Item type='Permission' typeId='C6A89FDE1294451497801DF78341B473' id='A8FC3EC44ED0462B9A32D4564FAC0AD8'>
+      <id keyed_name='Company' type='Permission'>A8FC3EC44ED0462B9A32D4564FAC0AD8</id>
+      <name>Company</name>
+    </Item>
+  </permission_id>
+  <itemtype>3E71E373FC2940B288760C915120AABE</itemtype>
+  <fake_prop>This is a fake prop for passing data</fake_prop>
+</Item></Result>").AssertItem();
+      var result = item.LazyMap(conn, i => new
+      {
+        FakeProp = i.Property("fake_prop").Value,
+        FakeAttr = i.Attribute("fake_attr").Value,
+        Empty = i.OwnedById().Value
+      });
+      Assert.AreEqual("This is a fake prop for passing data", result.FakeProp);
+      Assert.AreEqual("This is a fake attribute for passing data", result.FakeAttr);
+    }
+
+    [TestMethod()]
+    public void LazyMap_IncomingItemNotOverwrittenByDatabase()
+    {
+      var conn = new TestConnection();
+      var aml = ElementFactory.Local;
+      var item = aml.FromXml(@"<Result><Item action='update' type='Company' id='1470B001142748A5BB39CECB72CD83C8'>
+  <permission_id>
+    <Item type='Permission' typeId='C6A89FDE1294451497801DF78341B473' id='5B05BBB4945845248586C90BE83C7BDC'>
+      <id keyed_name='Restricted Company' type='Permission'>5B05BBB4945845248586C90BE83C7BDC</id>
+      <name>Restricted Company</name>
+    </Item>
+  </permission_id>
+</Item></Result>").AssertItem();
+      var result = item.LazyMap(conn, i => new
+      {
+        PermissionName = i.PermissionId().AsItem().Property("name").Value,
+        TypeId = i.TypeId().Value,
+        Empty = i.CreatedById().AsItem().Property("first_name").Value
+      });
+      Assert.AreEqual("Restricted Company", result.PermissionName);
+      Assert.AreEqual("3E71E373FC2940B288760C915120AABE", result.TypeId);
+      Assert.AreEqual("First", result.Empty);
     }
 
     [TestMethod()]

--- a/src/Innovator.ClientTests/Aml/ItemExtensionsTests.cs
+++ b/src/Innovator.ClientTests/Aml/ItemExtensionsTests.cs
@@ -46,7 +46,6 @@ namespace Innovator.Client.Tests
   <created_by_id keyed_name='First Last' type='User'>8227040ABF0A46A8AF06C18ABD3967B3</created_by_id>
   <id keyed_name='Some Company' type='Company'>BF3BF6C4795F431D880E7AF4D68D7A9C</id>
   <permission_id keyed_name='Company' type='Permission'>A8FC3EC44ED0462B9A32D4564FAC0AD8</permission_id>
-  <itemtype>3E71E373FC2940B288760C915120AABE</itemtype>
 </Item></Result>").AssertItem();
       var result = item.LazyMap(conn, i => new
       {
@@ -69,7 +68,6 @@ namespace Innovator.Client.Tests
       var item = aml.FromXml(@"<Result><Item type='Company' typeId='3E71E373FC2940B288760C915120AABE' id='BF3BF6C4795F431D880E7AF4D68D7A9C'>
   <created_by_id keyed_name='First Last' type='User'>8227040ABF0A46A8AF06C18ABD3967B3</created_by_id>
   <id keyed_name='Some Company' type='Company'>BF3BF6C4795F431D880E7AF4D68D7A9C</id>
-  <itemtype>3E71E373FC2940B288760C915120AABE</itemtype>
 </Item></Result>").AssertItem();
       var result = item.LazyMap(conn, i => new
       {
@@ -97,14 +95,12 @@ namespace Innovator.Client.Tests
       <itemtype>45E899CD2859442982EB22BB2DF683E5</itemtype>
     </Item>
   </created_by_id>
-  <id keyed_name='Another Company' type='Company'>0E086FFA6C4646F6939B74C43D094182</id>
   <permission_id keyed_name='Company' type='Permission'>
     <Item type='Permission' typeId='C6A89FDE1294451497801DF78341B473' id='A8FC3EC44ED0462B9A32D4564FAC0AD8'>
       <id keyed_name='Company' type='Permission'>A8FC3EC44ED0462B9A32D4564FAC0AD8</id>
       <name>Company</name>
     </Item>
   </permission_id>
-  <itemtype>3E71E373FC2940B288760C915120AABE</itemtype>
   <fake_prop>This is a fake prop for passing data</fake_prop>
 </Item></Result>").AssertItem();
       var result = item.LazyMap(conn, i => new
@@ -125,7 +121,6 @@ namespace Innovator.Client.Tests
       var item = aml.FromXml(@"<Result><Item action='update' type='Company' id='1470B001142748A5BB39CECB72CD83C8'>
   <permission_id>
     <Item type='Permission' typeId='C6A89FDE1294451497801DF78341B473' id='5B05BBB4945845248586C90BE83C7BDC'>
-      <id keyed_name='Restricted Company' type='Permission'>5B05BBB4945845248586C90BE83C7BDC</id>
       <name>Restricted Company</name>
     </Item>
   </permission_id>
@@ -134,11 +129,11 @@ namespace Innovator.Client.Tests
       {
         PermissionName = i.PermissionId().AsItem().Property("name").Value,
         TypeId = i.TypeId().Value,
-        Empty = i.CreatedById().AsItem().Property("first_name").Value
+        EmptyFirstName = i.CreatedById().AsItem().Property("first_name").Value
       });
       Assert.AreEqual("Restricted Company", result.PermissionName);
       Assert.AreEqual("3E71E373FC2940B288760C915120AABE", result.TypeId);
-      Assert.AreEqual("First", result.Empty);
+      Assert.AreEqual("First", result.EmptyFirstName);
     }
 
     [TestMethod()]
@@ -147,20 +142,52 @@ namespace Innovator.Client.Tests
       var conn = new TestConnection();
       var aml = ElementFactory.Local;
       var item = aml.FromXml(@"<Result><Item type='Company' typeId='3E71E373FC2940B288760C915120AABE' id='0E086FFA6C4646F6939B74C43D094182'>
-  <id keyed_name='Another Company' type='Company'>0E086FFA6C4646F6939B74C43D094182</id>
   <permission_id keyed_name='Company' type='Permission'>A8FC3EC44ED0462B9A32D4564FAC0AD8</permission_id>
-  <itemtype>3E71E373FC2940B288760C915120AABE</itemtype>
 </Item></Result>").AssertItem();
       var result = item.LazyMap(conn, i => new
       {
-        ItemType = i.Property("itemtype").Value,
-        PermissionItem = i.Property("permission_id").AsItem(),
-        PermissionItemId = i.Property("permission_id").AsItem().Id(),
         PermissionName = i.Property("permission_id").AsItem().Property("name").Value
       });
-      Assert.AreEqual("3E71E373FC2940B288760C915120AABE", result.ItemType);
-      Assert.AreEqual("A8FC3EC44ED0462B9A32D4564FAC0AD8", result.PermissionItemId);
       Assert.AreEqual("Company", result.PermissionName);
+    }
+
+    [TestMethod()]
+    public void LazyMap_ChangingProperty_NestedItem()
+    {
+      var conn = new TestConnection();
+      var aml = ElementFactory.Local;
+      var item = aml.FromXml(@"<Result><Item type='Company' typeId='3E71E373FC2940B288760C915120AABE' id='0E086FFA6C4646F6939B74C43D094182'>
+  <permission_id>F8BAD68CCADB43DF901FDCA693A22705</permission_id>
+  <owned_by_id>384C0326D719419F897C34163B8C5B2E</owned_by_id>
+</Item></Result>").AssertItem();
+      var result = item.LazyMap(conn, i => new
+      {
+        PermissionName = i.Property("permission_id").AsItem().Property("name").Value,
+        OwnedById = i.OwnedById().Value
+      });
+      Assert.AreEqual("Vault", result.PermissionName);
+      Assert.AreEqual("384C0326D719419F897C34163B8C5B2E", result.OwnedById);
+    }
+
+    [TestMethod()]
+    public void LazyMap_AddItemViaProperty()
+    {
+      var conn = new TestConnection();
+      var aml = ElementFactory.Local;
+      var item = aml.FromXml(@"<Result><Item type='Company' typeId='3E71E373FC2940B288760C915120AABE' id='0E086FFA6C4646F6939B74C43D094182'>
+  <permission_id>
+    <Item type='Permission' action='add'>
+      <name>New Company</name>
+    </Item>
+  </permission_id>
+</Item></Result>").AssertItem();
+      var result = item.LazyMap(conn, i => new
+      {
+        PermissionItemTypeName = i.Property("permission_id").AsItem().TypeName(),
+        PermissionName = i.Property("permission_id").AsItem().Property("name").Value
+      });
+      Assert.AreEqual("New Company", result.PermissionName);
+      Assert.AreEqual("Permission", result.PermissionItemTypeName);
     }
 
     [TestMethod()]

--- a/src/Innovator.ClientTests/Connection/ConnectionExtensionsTests.cs
+++ b/src/Innovator.ClientTests/Connection/ConnectionExtensionsTests.cs
@@ -1,7 +1,7 @@
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Globalization;
 using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Innovator.Client.Tests
 {
@@ -17,7 +17,7 @@ namespace Innovator.Client.Tests
         FirstName = i.CreatedById().AsItem().Property("first_name").Value,
         PermName = i.PermissionId().AsItem().Property("name").Value,
         KeyedName = i.Property("id").KeyedName().Value,
-        Empty = i.OwnedById().Value
+        Empty = i.ManagedById().Value
       });
       Assert.AreEqual("First", result.FirstName);
       Assert.AreEqual("Company", result.PermName);

--- a/src/Innovator.ClientTests/TestConnection.cs
+++ b/src/Innovator.ClientTests/TestConnection.cs
@@ -211,7 +211,7 @@ namespace Innovator.Client.Tests
             }
             break;
           case "ItemType":
-            if (AttrEquals(elem, "id", "4F1AC04A2B484F3ABA4E20DB63808A88"))
+            if (AttrEquals(elem, "id", "4F1AC04A2B484F3ABA4E20DB63808A88") || elem.Value == "Part")
             {
               result = @"<Result>
       <Item type='ItemType' typeId='450906E86E304F55A34B3C0D65C097EA' id='4F1AC04A2B484F3ABA4E20DB63808A88'>

--- a/src/Innovator.ClientTests/TestConnection.cs
+++ b/src/Innovator.ClientTests/TestConnection.cs
@@ -1,9 +1,9 @@
-using Innovator.Client.Connection;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Xml.Linq;
+using Innovator.Client.Connection;
 
 namespace Innovator.Client.Tests
 {
@@ -90,6 +90,26 @@ namespace Innovator.Client.Tests
     </Item>
   </created_by_id>
   <id keyed_name='Another Company' type='Company'>0E086FFA6C4646F6939B74C43D094182</id>
+  <permission_id keyed_name='Company' type='Permission'>
+    <Item type='Permission' typeId='C6A89FDE1294451497801DF78341B473' id='A8FC3EC44ED0462B9A32D4564FAC0AD8'>
+      <id keyed_name='Company' type='Permission'>A8FC3EC44ED0462B9A32D4564FAC0AD8</id>
+      <name>Company</name>
+    </Item>
+  </permission_id>
+  <itemtype>3E71E373FC2940B288760C915120AABE</itemtype>
+</Item>";
+            }
+            else if (AttrEquals(elem, "id", "1470B001142748A5BB39CECB72CD83C8"))
+            {
+              result = @"<Item type='Company' typeId='3E71E373FC2940B288760C915120AABE' id='1470B001142748A5BB39CECB72CD83C8'>
+  <created_by_id keyed_name='First Last' type='User'>
+    <Item type='User' typeId='45E899CD2859442982EB22BB2DF683E5' id='8227040ABF0A46A8AF06C18ABD3967B3'>
+      <id keyed_name='First Last' type='User'>8227040ABF0A46A8AF06C18ABD3967B3</id>
+      <itemtype>45E899CD2859442982EB22BB2DF683E5</itemtype>
+      <first_name>First</first_name>
+    </Item>
+  </created_by_id>
+  <id keyed_name='Best Company' type='Company'>1470B001142748A5BB39CECB72CD83C8</id>
   <permission_id keyed_name='Company' type='Permission'>
     <Item type='Permission' typeId='C6A89FDE1294451497801DF78341B473' id='A8FC3EC44ED0462B9A32D4564FAC0AD8'>
       <id keyed_name='Company' type='Permission'>A8FC3EC44ED0462B9A32D4564FAC0AD8</id>

--- a/src/Innovator.ClientTests/TestConnection.cs
+++ b/src/Innovator.ClientTests/TestConnection.cs
@@ -97,6 +97,7 @@ namespace Innovator.Client.Tests
     </Item>
   </permission_id>
   <itemtype>3E71E373FC2940B288760C915120AABE</itemtype>
+  <owned_by_id>44CC39EB107F4C02884AFF66A478202D</owned_by_id>
 </Item>";
             }
             else if (AttrEquals(elem, "id", "1470B001142748A5BB39CECB72CD83C8"))
@@ -124,7 +125,7 @@ namespace Innovator.Client.Tests
             if (AttrEquals(elem, "id", "2D246C5838644C1C8FD34F8D2796E327") || elem.Element("id")?.Value == "2D246C5838644C1C8FD34F8D2796E327")
             {
               result = @"<Result>
-  <Item type='User' typeId='45E899CD2859442982EB22BB2DF683E5' id='8227040ABF0A46A8AF06C18ABD3967B3'>
+  <Item type='User' typeId='45E899CD2859442982EB22BB2DF683E5' id='2D246C5838644C1C8FD34F8D2796E327'>
     <default_vault keyed_name='Default' type='Vault'>
       <Item type='Vault' typeId='8FC29FEF933641A09CEE13A604A9DC74' id='51C2A8877C4D4038A5A0C3071A863706'>
         <id keyed_name='Default' type='Vault'>51C2A8877C4D4038A5A0C3071A863706</id>
@@ -134,7 +135,7 @@ namespace Innovator.Client.Tests
         <vault_url>http://server/innovator11sp12/vault/vaultserver.aspx</vault_url>
       </Item>
     </default_vault>
-    <id keyed_name='First Last' type='User'>8227040ABF0A46A8AF06C18ABD3967B3</id>
+    <id keyed_name='First Last' type='User'>2D246C5838644C1C8FD34F8D2796E327</id>
     <itemtype>45E899CD2859442982EB22BB2DF683E5</itemtype>
     <Relationships>
       <Item type='ReadPriority' typeId='8CFAF78BCFFB41E6A3ED838D9EC2FD7C' id='749A3C52A15247F4AB7EDE406AA19AF8'>
@@ -150,8 +151,8 @@ namespace Innovator.Client.Tests
           </Item>
         </related_id>
         <source_id keyed_name='First Last' type='User'>
-          <Item type='User' typeId='45E899CD2859442982EB22BB2DF683E5' id='8227040ABF0A46A8AF06C18ABD3967B3'>
-            <id keyed_name='First Last' type='User'>8227040ABF0A46A8AF06C18ABD3967B3</id>
+          <Item type='User' typeId='45E899CD2859442982EB22BB2DF683E5' id='2D246C5838644C1C8FD34F8D2796E327'>
+            <id keyed_name='First Last' type='User'>2D246C5838644C1C8FD34F8D2796E327</id>
             <itemtype>45E899CD2859442982EB22BB2DF683E5</itemtype>
           </Item>
         </source_id>
@@ -169,6 +170,30 @@ namespace Innovator.Client.Tests
 </Item></Result>";
             }
             break;
+          case "Identity":
+            if (AttrEquals(elem, "id", "44CC39EB107F4C02884AFF66A478202D"))
+            {
+              result = @"<Result>
+  <Item type='Identity' typeId='E582AB17663F4EF28460015B2BE9E094' id='44CC39EB107F4C02884AFF66A478202D'>
+    <id keyed_name='First Last' type='Identity'>44CC39EB107F4C02884AFF66A478202D</id>
+    <is_alias>1</is_alias>
+    <name>First Last</name>
+    <itemtype>E582AB17663F4EF28460015B2BE9E094</itemtype>
+  </Item>
+</Result>";
+            }
+            else if (AttrEquals(elem, "id", "384C0326D719419F897C34163B8C5B2E"))
+            {
+              result = @"<Result>
+  <Item type='Identity' typeId='E582AB17663F4EF28460015B2BE9E094' id='384C0326D719419F897C34163B8C5B2E'>
+    <id keyed_name='John Doe' type='Identity'>384C0326D719419F897C34163B8C5B2E</id>
+    <is_alias>1</is_alias>
+    <name>John Doe</name>
+    <itemtype>E582AB17663F4EF28460015B2BE9E094</itemtype>
+  </Item>
+</Result>";
+            }
+            break;
           case "Permission":
             if (AttrEquals(elem, "id", "A8FC3EC44ED0462B9A32D4564FAC0AD8"))
             {
@@ -177,11 +202,18 @@ namespace Innovator.Client.Tests
   <name>Company</name>
 </Item></Result>";
             }
+            else if (AttrEquals(elem, "id", "F8BAD68CCADB43DF901FDCA693A22705"))
+            {
+              result = @"<Result><Item type='Permission' typeId='C6A89FDE1294451497801DF78341B473' id='F8BAD68CCADB43DF901FDCA693A22705'>
+  <id keyed_name='Vault' type='Permission'>F8BAD68CCADB43DF901FDCA693A22705</id>
+  <name>Vault</name>
+</Item></Result>";
+            }
             break;
           case "ItemType":
-            result = @"<SOAP-ENV:Envelope xmlns:SOAP-ENV='http://schemas.xmlsoap.org/soap/envelope/'>
-  <SOAP-ENV:Body>
-    <Result>
+            if (AttrEquals(elem, "id", "4F1AC04A2B484F3ABA4E20DB63808A88"))
+            {
+              result = @"<Result>
       <Item type='ItemType' typeId='450906E86E304F55A34B3C0D65C097EA' id='4F1AC04A2B484F3ABA4E20DB63808A88'>
         <allow_private_permission>1</allow_private_permission>
         <auto_search>0</auto_search>
@@ -219,9 +251,25 @@ namespace Innovator.Client.Tests
         <use_src_access>0</use_src_access>
         <name>Part</name>
       </Item>
-    </Result>
-  </SOAP-ENV:Body>
-</SOAP-ENV:Envelope>";
+    </Result>";
+            }
+            break;
+          case "Property":
+            if (elem.Element("source_id")?.Value == "Company")
+            {
+              result = @"<Result>
+  <Item type='Property' typeId='26D7CD4E033242148E2724D3D054B4D3' id='264EA3A8B7D14D0587EFB79365FF28A2'>
+    <data_source keyed_name='Permission' type='ItemType' name='Permission'>C6A89FDE1294451497801DF78341B473</data_source>
+    <data_type>item</data_type>
+    <name>permission_id</name>
+  </Item>
+  <Item type='Property' typeId='26D7CD4E033242148E2724D3D054B4D3' id='E6B16DA893644CFDBC62A4EAF68C61A1'>
+    <data_source keyed_name='Identity' type='ItemType' name='Identity'>E582AB17663F4EF28460015B2BE9E094</data_source>
+    <data_type>item</data_type>
+    <name>owned_by_id</name>
+  </Item>
+</Result>";
+            }
             break;
         }
       }


### PR DESCRIPTION
It was found that if LazyMap had to do a get for any property it would only run the mapping on what was returned, and lose any data on the incoming item. This lead to different behaviour if all of the mapped properties were sent on the incoming item or only some of the properties were sent.
This fix instead takes the incoming item and merges it with the data from the server, handling properties, nested items in properties, and attributes.
This passes all tests in the repo (except for the broken TimeZoneTests test) plus 2 new tests written for this behavior.