### PR TITLE
IsChanging - Check only the changing properties against their existing values

### DIFF
--- a/src/Innovator.Client/Server/ServerMethod/ValidationContext.cs
+++ b/src/Innovator.Client/Server/ServerMethod/ValidationContext.cs
@@ -122,13 +122,14 @@ namespace Innovator.Server
     public bool IsChanging(params string[] names)
     {
       // Are any of the properties in the changing item?
-      var propExists = names.Any(n => Item.Property(n).Exists);
-      if (!propExists) return false;
+      var existingProperties = names.Where(n => Item.Property(n).Exists);
+      if (!existingProperties.Any()) return false;
 
       // Is this new?
       if (IsNew) return true;
 
-      return names.Any(n => Item.Property(n).Value != _existing.Property(n).Value);
+      // Check only the changing properties against their existing values
+      return existingProperties.Any(n => Item.Property(n).Value != _existing.Property(n).Value);
     }
 
     /// <summary>

--- a/src/Innovator.ClientTests/Innovator.ClientTests.csproj
+++ b/src/Innovator.ClientTests/Innovator.ClientTests.csproj
@@ -115,6 +115,7 @@
     <Compile Include="QueryModel\PatternTests.cs" />
     <Compile Include="QueryModel\WhereParserTests.cs" />
     <Compile Include="Scratchpad.cs" />
+    <Compile Include="Server\ContextTests.cs" />
     <Compile Include="TestConnection.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="CommandFileTests.cs" />

--- a/src/Innovator.ClientTests/Server/ContextTests.cs
+++ b/src/Innovator.ClientTests/Server/ContextTests.cs
@@ -1,0 +1,35 @@
+using System;
+using Innovator.Server;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Innovator.Client.Tests.Server
+{
+  [TestClass]
+  public class ContextTests
+  {
+    [TestMethod]
+    public void ValidationContext_IsChanging_WorksCorrectly()
+    {
+      var conn = new TestConnection();
+      var aml = conn.AmlContext;
+
+      var changes = aml.FromXml(@"<Item type='User' action='update' id='49403709D9F847ECA1A2DE9ADE68660F'>
+  <first_name>John</first_name>
+</Item>").AssertItem();
+      var validationContext = new ValidationContext(conn, changes);
+
+      Assert.IsFalse(validationContext.IsChanging("first_name"));
+      Assert.IsFalse(validationContext.IsChanging("first_name", "last_name"));
+      Assert.IsFalse(validationContext.IsChanging("last_name"));
+
+      changes = aml.FromXml(@"<Item type='User' action='update' id='49403709D9F847ECA1A2DE9ADE68660F'>
+  <first_name>Jim</first_name>
+</Item>").AssertItem();
+      validationContext = new ValidationContext(conn, changes);
+
+      Assert.IsTrue(validationContext.IsChanging("first_name"));
+      Assert.IsTrue(validationContext.IsChanging("first_name", "last_name"));
+      Assert.IsFalse(validationContext.IsChanging("last_name"));
+    }
+  }
+}

--- a/src/Innovator.ClientTests/TestConnection.cs
+++ b/src/Innovator.ClientTests/TestConnection.cs
@@ -4,10 +4,11 @@ using System.IO;
 using System.Text;
 using System.Xml.Linq;
 using Innovator.Client.Connection;
+using Innovator.Server;
 
 namespace Innovator.Client.Tests
 {
-  internal class TestConnection : IArasConnection
+  internal class TestConnection : IArasConnection, IServerConnection
   {
     private ArasVaultConnection _vaultConn;
 
@@ -39,6 +40,18 @@ namespace Innovator.Client.Tests
     </SOAP-ENV:Fault>
   </SOAP-ENV:Body>
 </SOAP-ENV:Envelope>";
+
+    public IServerCache ApplicationCache => throw new NotImplementedException();
+
+    public string OriginalRequest => throw new NotImplementedException();
+
+    public IServerPermissions Permissions => throw new NotImplementedException();
+
+    public IServerCache RequestState => throw new NotImplementedException();
+
+    public string RequestUrl => throw new NotImplementedException();
+
+    public IServerCache SessionCache => throw new NotImplementedException();
 
     public TestConnection()
     {
@@ -166,6 +179,15 @@ namespace Innovator.Client.Tests
               result = @"<Result><Item type='User' typeId='45E899CD2859442982EB22BB2DF683E5' id='8227040ABF0A46A8AF06C18ABD3967B3'>
   <id keyed_name='First Last' type='User'>8227040ABF0A46A8AF06C18ABD3967B3</id>
   <first_name>First</first_name>
+  <itemtype>45E899CD2859442982EB22BB2DF683E5</itemtype>
+</Item></Result>";
+            }
+            else if (AttrEquals(elem, "id", "49403709D9F847ECA1A2DE9ADE68660F"))
+            {
+              result = @"<Result><Item type='User' typeId='45E899CD2859442982EB22BB2DF683E5' id='49403709D9F847ECA1A2DE9ADE68660F'>
+  <id keyed_name='John Doe' type='User'>49403709D9F847ECA1A2DE9ADE68660F</id>
+  <first_name>John</first_name>
+  <last_name>Doe</last_name>
   <itemtype>45E899CD2859442982EB22BB2DF683E5</itemtype>
 </Item></Result>";
             }
@@ -306,6 +328,11 @@ namespace Innovator.Client.Tests
     }
 
     public IPromise<ExplicitHashCredentials> HashCredentials(ICredentials credentials, bool async)
+    {
+      throw new NotImplementedException();
+    }
+
+    public string GetHeader(string name)
     {
       throw new NotImplementedException();
     }


### PR DESCRIPTION
IsChanging was returning true when checking multiple properties and the context item had one of the properties filled out but matching the database value, meaning it should return false. It was incorrectly checking all of the listed properties against the database instead of just the one in the context item.