### PR TITLE
OAuth connection improvements

### DIFF
--- a/src/Innovator.Client/Authentication/AuthenticationFactory.cs
+++ b/src/Innovator.Client/Authentication/AuthenticationFactory.cs
@@ -56,11 +56,18 @@ namespace Innovator.Client
         .Progress(result.Notify)
         .Done(r =>
         {
-          var config = new OAuthConfig(r.AsStream, oauthBaseUri);
-          if (config.ProtocolVersion >= new Version("1.0"))
-            result.Resolve(new OAuthAuthenticator(service, config, creds));
-          else
-            result.Resolve(new LegacyAuthenticator(innovatorServerBaseUrl, creds));
+          try
+          {
+            var config = new OAuthConfig(r.AsString(), oauthBaseUri);
+            if (config.ProtocolVersion >= new Version("1.0"))
+              result.Resolve(new OAuthAuthenticator(service, config, creds));
+            else
+              result.Resolve(new LegacyAuthenticator(innovatorServerBaseUrl, creds));
+          }
+          catch (Exception ex)
+          {
+            result.Reject(ex);
+          }
         })
         .Fail(e =>
         {

--- a/src/Innovator.Client/Authentication/OAuthConfig.cs
+++ b/src/Innovator.Client/Authentication/OAuthConfig.cs
@@ -10,7 +10,7 @@ namespace Innovator.Client
     public Version ProtocolVersion { get; } = new Version(0, 0);
     public ProtocolType ProtocolType { get; }
 
-    public OAuthConfig(Stream json, Uri baseUri)
+    public OAuthConfig(string json, Uri baseUri)
     {
       AuthorizeEndpoint = new Uri(baseUri, "connect/authorize");
       TokenEndpoint = new Uri(baseUri, "connect/token");

--- a/src/Innovator.Client/Connection/MappedConnection.cs
+++ b/src/Innovator.Client/Connection/MappedConnection.cs
@@ -144,11 +144,15 @@ namespace Innovator.Client.Connection
 
     public Stream Process(Command request)
     {
+      if (_current == null)
+        throw new LoggedOutException("You are not connected to Aras. Please log in.");
       return _current.Process(request);
     }
 
     public IPromise<Stream> Process(Command request, bool async)
     {
+      if (_current == null)
+        throw new LoggedOutException("You are not connected to Aras. Please log in.");
       return _current.Process(request, async);
     }
 


### PR DESCRIPTION
- Force the oauth config to be read as a string.
- Fix issue where the promise chain was broken by an exception.
- Return a LoggedOutException to prevent a null reference.

The .AsString() in AuthenticationFactory isn't a great fix but it fixed the issue. I wasn't able to reproduce the issue outside of our codebase but some of the time the json stream wouldn't be fully loaded when it tried to read it so it failed as being malformed. Turning the json into a string fixes it.